### PR TITLE
Fix typo in  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ let aws_signer = AWSSigner::new();
 Unit tests require KMS credentials to be set. Please set these values in your environment.
 ```
 export ACCESS_KEY=<ACCESS_KEY>
-eexport SECRET_ACCESS_KEY=<SECRET_ACCESS_KEY>
+export SECRET_ACCESS_KEY=<SECRET_ACCESS_KEY>
 export KEY_ID=<KEY_ID>
 export REGION=<REGION<
 ```


### PR DESCRIPTION
It fixes a small typo that caught my eye in the readme export part.